### PR TITLE
Support Python 2.7

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,6 +4,8 @@ os: Visual Studio 2015
 
 environment:
   matrix:
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
       env: CHECK_DOCS=1
     - python: 3.6
       env: CHECK_FORMATTING=1
+    - python: pypy2.7-7.1.1
+    - python: 2.7
     - python: pypy3.5
     - python: 3.5
     - python: 3.6

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
+import io
+
 from setuptools import setup, find_packages
 
-exec(open("src/unasync/_version.py", encoding="utf-8").read())
+exec(io.open("src/unasync/_version.py", encoding="utf-8").read())
 
-LONG_DESC = open("README.rst", encoding="utf-8").read()
+LONG_DESC = io.open("README.rst", encoding="utf-8").read()
 
 setup(
     name="unasync",
@@ -19,7 +21,7 @@ setup(
     package_dir={"": "src"},
     install_requires=[],
     keywords=["async"],
-    python_requires=">=3.5",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "License :: OSI Approved :: Apache Software License",

--- a/src/unasync/__init__.py
+++ b/src/unasync/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import print_function
 
+
+import errno
 import os
 import tokenize as std_tokenize
 from tokenize import NAME, NEWLINE, NL, STRING, ENCODING
@@ -67,6 +69,14 @@ def untokenize(tokens):
     return "".join(space + tokval for space, tokval in tokens)
 
 
+def makedirs_existok(dir):
+    try:
+        os.makedirs(dir)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+
+
 def unasync_file(filepath, fromdir, todir):
     with open(filepath, "rb") as f:
         encoding, _ = std_tokenize.detect_encoding(f.readline)
@@ -75,7 +85,7 @@ def unasync_file(filepath, fromdir, todir):
         tokens = unasync_tokens(tokens)
         result = untokenize(tokens)
         outfilepath = filepath.replace(fromdir, todir)
-        os.makedirs(os.path.dirname(outfilepath), exist_ok=True)
+        makedirs_existok(os.path.dirname(outfilepath))
         with open(outfilepath, "w", encoding=encoding) as f:
             print(result, file=f, end="")
 

--- a/src/unasync/__init__.py
+++ b/src/unasync/__init__.py
@@ -106,6 +106,8 @@ def unasync_file(filepath, fromdir, todir):
 
 class build_py(orig.build_py):
     """
+    Subclass build_py from setuptools to modify its behavior.
+
     Convert files in _async dir from being asynchronous to synchronous
     and saves them in _sync dir.
     """
@@ -120,6 +122,7 @@ class build_py(orig.build_py):
             self.build_packages()
             self.build_package_data()
 
+        # Our modification!
         for f in self._updated_files:
             if os.sep + "_async" + os.sep in f:
                 unasync_file(f, "_async", "_sync")

--- a/src/unasync/__init__.py
+++ b/src/unasync/__init__.py
@@ -4,7 +4,7 @@ import os
 import tokenize as std_tokenize
 from tokenize import NAME, NEWLINE, NL, STRING, ENCODING
 
-from setuptools.command.build_py import build_py
+from setuptools.command import build_py as orig
 
 from ._version import __version__  # NOQA
 
@@ -78,7 +78,7 @@ def unasync_file(filepath, fromdir, todir):
             print(result, file=f, end="")
 
 
-class build_py(build_py):
+class build_py(orig.build_py):
     """
     Convert files in _async dir from being asynchronous to synchronous
     and saves them in _sync dir.
@@ -102,7 +102,7 @@ class build_py(build_py):
         self.byte_compile(self.get_outputs(include_bytecode=0))
 
     def build_module(self, module, module_file, package):
-        outfile, copied = super().build_module(module, module_file, package)
+        outfile, copied = orig.build_py.build_module(self, module, module_file, package)
         if copied:
             self._updated_files.append(outfile)
         return outfile, copied

--- a/src/unasync/__init__.py
+++ b/src/unasync/__init__.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 import errno
 import os
 import tokenize as std_tokenize
-from tokenize import NAME, NEWLINE, NL, STRING, ENCODING
 
 from setuptools.command import build_py as orig
 
@@ -28,11 +27,11 @@ ASYNC_TO_SYNC = {
 def tokenize(f):
     last_end = (1, 0)
     for tok in std_tokenize.tokenize(f.readline):
-        if tok.type == ENCODING:
+        if tok.type == std_tokenize.ENCODING:
             continue
 
         if last_end[0] < tok.start[0]:
-            yield ("", STRING, " \\\n")
+            yield ("", std_tokenize.STRING, " \\\n")
             last_end = (tok.start[0], 0)
 
         space = ""
@@ -42,7 +41,7 @@ def tokenize(f):
         yield (space, tok.type, tok.string)
 
         last_end = tok.end
-        if tok.type in [NEWLINE, NL]:
+        if tok.type in [std_tokenize.NEWLINE, std_tokenize.NL]:
             last_end = (tok.end[0] + 1, 0)
 
 
@@ -57,7 +56,7 @@ def unasync_tokens(tokens):
             # `print( stuff)`
             used_space = space
         else:
-            if toknum == NAME and tokval in ASYNC_TO_SYNC:
+            if toknum == std_tokenize.NAME and tokval in ASYNC_TO_SYNC:
                 tokval = ASYNC_TO_SYNC[tokval]
             if used_space is None:
                 used_space = space

--- a/src/unasync/__init__.py
+++ b/src/unasync/__init__.py
@@ -1,12 +1,12 @@
 """Top-level package for unasync."""
 
-from ._version import __version__
-
-from setuptools.command.build_py import build_py
-
 import os
 import tokenize as std_tokenize
 from tokenize import NAME, NEWLINE, NL, STRING, ENCODING
+
+from setuptools.command.build_py import build_py
+
+from ._version import __version__  # NOQA
 
 ASYNC_TO_SYNC = {
     "__aenter__": "__enter__",

--- a/src/unasync/__init__.py
+++ b/src/unasync/__init__.py
@@ -1,5 +1,7 @@
 """Top-level package for unasync."""
 
+from __future__ import print_function
+
 import os
 import tokenize as std_tokenize
 from tokenize import NAME, NEWLINE, NL, STRING, ENCODING

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,2 @@
 pytest-cov
+backports.tempfile

--- a/tests/async/encoding.py
+++ b/tests/async/encoding.py
@@ -1,0 +1,6 @@
+# -*- coding: latin1 -*-
+
+
+def f():
+    # non ASCII character encoded as latin1 (not UTF-8)
+    return "Le café, ça réveille !"

--- a/tests/async/simple.py
+++ b/tests/async/simple.py
@@ -2,6 +2,7 @@ class TestImplementation:
     def __init__(self, a, b):
         self.a = a
         self.b = b
+        self.s = "UTF-8: ❄"
 
     async def get_a_b(self):
         s = "a is %s b is %s" % \

--- a/tests/sync/encoding.py
+++ b/tests/sync/encoding.py
@@ -1,0 +1,6 @@
+# -*- coding: latin1 -*-
+
+
+def f():
+    # non ASCII character encoded as latin1 (not UTF-8)
+    return "Le café, ça réveille !"

--- a/tests/sync/simple.py
+++ b/tests/sync/simple.py
@@ -2,6 +2,7 @@ class TestImplementation:
     def __init__(self, a, b):
         self.a = a
         self.b = b
+        self.s = "UTF-8: ❄"
 
     def get_a_b(self):
         s = "a is %s b is %s" % \

--- a/tests/test_unasync.py
+++ b/tests/test_unasync.py
@@ -2,9 +2,9 @@ import copy
 import os
 import shutil
 import subprocess
-import tempfile
 
 import pytest
+from backports import tempfile
 
 import unasync
 

--- a/tests/test_unasync.py
+++ b/tests/test_unasync.py
@@ -1,4 +1,5 @@
 import copy
+import io
 import os
 import shutil
 import subprocess
@@ -21,9 +22,10 @@ def test_unasync(source_file):
             os.path.join(ASYNC_DIR, source_file), fromdir=ASYNC_DIR, todir=tmpdir
         )
 
-        with open(os.path.join(SYNC_DIR, source_file)) as f:
+        encoding = 'latin-1' if 'encoding' in source_file else 'utf-8'
+        with io.open(os.path.join(SYNC_DIR, source_file), encoding=encoding) as f:
             truth = f.read()
-        with open(os.path.join(tmpdir, source_file)) as f:
+        with io.open(os.path.join(tmpdir, source_file), encoding=encoding) as f:
             unasynced_code = f.read()
             assert unasynced_code == truth
 

--- a/tests/test_unasync.py
+++ b/tests/test_unasync.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 
 import pytest
+# Needed to get tempfile.TemporaryDirectory in Python 2
 from backports import tempfile
 
 import unasync


### PR DESCRIPTION
Now that Python 2.7 support in python-trio/urllib3 could be a differentiating feature, I thought that I would see how hard Python 2.7 support could be in unasync. Turns out it was not that hard!