### PR TITLE
Add test to verify dir structure after build

### DIFF
--- a/tests/example_pkg/setup.py
+++ b/tests/example_pkg/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     author_email="author@example.com",
     description="A package used to test unasync",
     url="https://github.com/pypa/sampleproject",
-    packages=["example_pkg", "example_pkg._async"],
+    packages=["example_pkg", "example_pkg._async", "example_pkg._async.some_dir"],
     cmdclass={"build_py": unasync.build_py},
     package_dir={"": "src"},
 )

--- a/tests/example_pkg/src/example_pkg/_async/another_file.py
+++ b/tests/example_pkg/src/example_pkg/_async/another_file.py
@@ -1,0 +1,2 @@
+async def f():
+    return await 1

--- a/tests/example_pkg/src/example_pkg/_async/some_dir/__init__.py
+++ b/tests/example_pkg/src/example_pkg/_async/some_dir/__init__.py
@@ -1,0 +1,2 @@
+async def f():
+    return await 1

--- a/tests/example_pkg/src/example_pkg/_async/some_dir/another_file.py
+++ b/tests/example_pkg/src/example_pkg/_async/some_dir/another_file.py
@@ -1,0 +1,2 @@
+async def f():
+    return await 1

--- a/tests/example_pkg/src/example_pkg/_async/some_dir/some_file.py
+++ b/tests/example_pkg/src/example_pkg/_async/some_dir/some_file.py
@@ -1,0 +1,2 @@
+async def f():
+    return await 1

--- a/tests/example_pkg/src/example_pkg/_async/some_file.py
+++ b/tests/example_pkg/src/example_pkg/_async/some_file.py
@@ -1,0 +1,2 @@
+async def f():
+    return await 1

--- a/tests/test_unasync.py
+++ b/tests/test_unasync.py
@@ -72,7 +72,7 @@ def test_project_structure_after_build_py():
         env["PYTHONPATH"] = os.path.realpath(os.path.join(TEST_DIR, ".."))
         subprocess.check_call(["python", "setup.py", "build"], cwd=pkg_dir, env=env)
 
-        print(list_files("./tests/example_pkg/src/example_pkg/_async/."))
+        print(list_files(os.path.join(source_pkg_dir, "src/example_pkg/_async/.")))
         print(list_files(os.path.join(pkg_dir, "build/lib/example_pkg/_sync/.")))
 
-        assert list_files("./tests/example_pkg/src/example_pkg/_async/") == list_files('build/lib/example_pkg/_sync/')
+        assert list_files(os.path.join(tmpdir, "src/example_pkg/_async/.")) == list_files(os.path.join(pkg_dir, "build/lib/example_pkg/_sync/."))

--- a/tests/test_unasync.py
+++ b/tests/test_unasync.py
@@ -75,4 +75,4 @@ def test_project_structure_after_build_py():
         print(list_files(os.path.join(source_pkg_dir, "src/example_pkg/_async/.")))
         print(list_files(os.path.join(pkg_dir, "build/lib/example_pkg/_sync/.")))
 
-        assert list_files(os.path.join(tmpdir, "src/example_pkg/_async/.")) == list_files(os.path.join(pkg_dir, "build/lib/example_pkg/_sync/."))
+        assert list_files(os.path.join(source_pkg_dir, "src/example_pkg/_async/.")) == list_files(os.path.join(pkg_dir, "build/lib/example_pkg/_sync/."))

--- a/tests/test_unasync.py
+++ b/tests/test_unasync.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 
 import pytest
+
 # Needed to get tempfile.TemporaryDirectory in Python 2
 from backports import tempfile
 
@@ -16,6 +17,20 @@ SYNC_DIR = os.path.join(TEST_DIR, "sync")
 TEST_FILES = sorted([f for f in os.listdir(ASYNC_DIR) if f.endswith(".py")])
 
 
+def list_files(startpath):
+    output = ""
+    for root, dirs, files in os.walk(startpath):
+        level = root.replace(startpath, "").count(os.sep)
+        indent = " " * 4 * (level)
+        output += "{}{}/".format(indent, os.path.basename(root))
+        output += "\n"
+        subindent = " " * 4 * (level + 1)
+        for f in files:
+            output += "{}{}".format(subindent, f)
+            output += "\n"
+    return output
+
+
 @pytest.mark.parametrize("source_file", TEST_FILES)
 def test_unasync(source_file):
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -23,7 +38,7 @@ def test_unasync(source_file):
             os.path.join(ASYNC_DIR, source_file), fromdir=ASYNC_DIR, todir=tmpdir
         )
 
-        encoding = 'latin-1' if 'encoding' in source_file else 'utf-8'
+        encoding = "latin-1" if "encoding" in source_file else "utf-8"
         with io.open(os.path.join(SYNC_DIR, source_file), encoding=encoding) as f:
             truth = f.read()
         with io.open(os.path.join(tmpdir, source_file), encoding=encoding) as f:
@@ -45,3 +60,19 @@ def test_build_py():
         with open(unasynced) as f:
             unasynced_code = f.read()
             assert unasynced_code == "def f():\n    return 1\n"
+
+
+def test_project_structure_after_build_py():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        source_pkg_dir = os.path.join(TEST_DIR, "example_pkg")
+        pkg_dir = os.path.join(tmpdir, "example_pkg")
+        shutil.copytree(source_pkg_dir, pkg_dir)
+
+        env = copy.copy(os.environ)
+        env["PYTHONPATH"] = os.path.realpath(os.path.join(TEST_DIR, ".."))
+        subprocess.check_call(["python", "setup.py", "build"], cwd=pkg_dir, env=env)
+
+        print(list_files("./tests/example_pkg/src/example_pkg/_async/."))
+        print(list_files(os.path.join(pkg_dir, "build/lib/example_pkg/_sync/.")))
+
+        assert list_files("./tests/example_pkg/src/example_pkg/_async/") == list_files('build/lib/example_pkg/_sync/')


### PR DESCRIPTION
I am checking the directory tree of `_async` folder in the source of package and the directory tree of `_sync` folder after building the package, according to https://github.com/python-trio/unasync/issues/38 both of these should match, but the directory structure looks like this 

- For `_async` folder of source
```
./
    another_file.py
    some_file.py
    __init__.py
    some_dir/
        another_file.py
        some_file.py
        __init__.py
```
- For `_sync` folder after build
```
./
    another_file.py
    some_file.py
    __init__.py
```
