### PR TITLE
Allow to substitute using arbitrary regexes

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -70,6 +70,12 @@ Then create a file **pyproject.toml** in the root of your project and mention **
 
 And when you will build your package you will get your synchronous code in **_sync** folder.
 
+API
+---
+
+You can call unasync directly using :func:`unasync.unasync_file`.
+
+.. autofunction:: unasync.unasync_file
 
 .. toctree::
    :maxdepth: 2

--- a/tests/data/substitutions/urllib3_async.py
+++ b/tests/data/substitutions/urllib3_async.py
@@ -1,0 +1,7 @@
+from urllib3 import AsyncPoolManager
+
+
+async def test_redirect(self):
+    with AsyncPoolManager(backend="trio") as http:
+        r = await http.request("GET", "/")
+        assert r.status == 200

--- a/tests/data/substitutions/urllib3_sync.py
+++ b/tests/data/substitutions/urllib3_sync.py
@@ -1,0 +1,7 @@
+from urllib3 import PoolManager
+
+
+def test_redirect(self):
+    with PoolManager() as http:
+        r = http.request("GET", "/")
+        assert r.status == 200

--- a/tests/test_unasync.py
+++ b/tests/test_unasync.py
@@ -43,6 +43,23 @@ def test_unasync(tmpdir, source_file):
         assert unasynced_code == truth
 
 
+def test_unasync_substitutions(tmpdir):
+    FROM_DIR = os.path.join(TEST_DIR, "substitutions")
+    unasync.unasync_file(
+        os.path.join(FROM_DIR, "urllib3_async.py"),
+        fromdir=FROM_DIR,
+        todir=str(tmpdir),
+        substitutions={'backend="trio"': ""},
+    )
+
+    with open(os.path.join(FROM_DIR, "urllib3_sync.py")) as f:
+        truth = f.read()
+    with open(os.path.join(str(tmpdir), "urllib3_async.py")) as f:
+        unasynced_code = f.read()
+
+    assert unasynced_code == truth
+
+
 def test_build_py_modules(tmpdir):
 
     source_modules_dir = os.path.join(TEST_DIR, "example_mod")


### PR DESCRIPTION
This feature should allow us to generate sync tests from async tests for urllib3. I may expose something at a higher-level later but for now this should suffice because I don't know how what the layout of files is going to be, and the flexibility will allow to eg. only transform one file for now.

I did not check if the call to re.sub() is going to slow down things, but it's probably dwarfed by the time it takes to actually run the test suite.

Closes #45 