### PR TITLE
Support renaming custom classes

### DIFF
--- a/src/unasync/__init__.py
+++ b/src/unasync/__init__.py
@@ -18,6 +18,9 @@ ASYNC_TO_SYNC = {
     "__aiter__": "__iter__",
     "__anext__": "__next__",
     "asynccontextmanager": "contextmanager",
+    "AsyncIterable": "Iterable",
+    "AsyncIterator": "Iterator",
+    "AsyncGenerator": "Generator",
     # TODO StopIteration is still accepted in Python 2, but the right change
     # is 'raise StopAsyncIteration' -> 'return' since we want to use unasynced
     # code in Python 3.7+
@@ -68,8 +71,16 @@ def unasync_tokens(tokens):
             # `print( stuff)`
             used_space = space
         else:
-            if toknum == std_tokenize.NAME and tokval in ASYNC_TO_SYNC:
-                tokval = ASYNC_TO_SYNC[tokval]
+            if toknum == std_tokenize.NAME:
+                if tokval in ASYNC_TO_SYNC:
+                    tokval = ASYNC_TO_SYNC[tokval]
+                # Convert classes prefixed with 'Async' into 'Sync'
+                elif (
+                    len(tokval) > 5
+                    and tokval.startswith("Async")
+                    and tokval[5].isupper()
+                ):
+                    tokval = "Sync" + tokval[5:]
             if used_space is None:
                 used_space = space
             yield (used_space, tokval)

--- a/tests/data/async/classes.py
+++ b/tests/data/async/classes.py
@@ -1,0 +1,3 @@
+class AsyncSocket(object):
+    async def send_all(self, data):
+        ...

--- a/tests/data/async/typing.py
+++ b/tests/data/async/typing.py
@@ -1,0 +1,5 @@
+import typing
+
+typing.AsyncIterable[bytes]
+typing.AsyncIterator[bytes]
+typing.AsyncGenerator[bytes]

--- a/tests/data/sync/classes.py
+++ b/tests/data/sync/classes.py
@@ -1,0 +1,3 @@
+class SyncSocket(object):
+    def send_all(self, data):
+        ...

--- a/tests/data/sync/typing.py
+++ b/tests/data/sync/typing.py
@@ -1,0 +1,5 @@
+import typing
+
+typing.Iterable[bytes]
+typing.Iterator[bytes]
+typing.Generator[bytes]


### PR DESCRIPTION
Adds support for having custom classes named `AsyncXYZ` and they will be renamed to `SyncXYZ`. Also adds more type hints so that this new class name functionality doesn't break those type annotations.

This version of unasync works for the high-level Hip branch.