### PR TITLE
Drop support for Python 3.4

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,6 @@ os: Visual Studio 2015
 environment:
   matrix:
     - PYTHON: "C:\\Python27-x64"
-    - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ matrix:
     - python: pypy2.7-7.1.1
     - python: 2.7
     - python: pypy3.5
-    - python: 3.4
     - python: 3.5
     - python: 3.6
     - python: 3.7

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,9 +3,6 @@ norecursedirs = .git .* *.egg* old docs dist build
 addopts = -rw
 filterwarnings =
     error
-    # python3.4 raises this when importing setuptools
-    ignore:The value of convert_charrefs will become True in 3.5.*:DeprecationWarning
-
     # To ignore warning for deprecated imp module in setuptools
     ignore:the imp module is deprecated.*:PendingDeprecationWarning
     ignore:the imp module is deprecated.*:DeprecationWarning:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     package_dir={"": "src"},
     install_requires=[],
     keywords=["async"],
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "License :: OSI Approved :: Apache Software License",
@@ -32,7 +32,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Our Python 3.4 test suite fails due to colorama not supporting Python 3.4 any longer. We should probably remove support as well.