### PR TITLE
Bump version to 0.4.0+dev

### DIFF
--- a/src/unasync/_version.py
+++ b/src/unasync/_version.py
@@ -1,3 +1,3 @@
 # This file is imported from __init__.py and exec'd from setup.py
 
-__version__ = "0.4.0"
+__version__ = "0.4.0+dev"


### PR DESCRIPTION
Now that https://pypi.org/project/unasync/0.4.0/ is on PyPI