### PR TITLE
Allow custom directory in place of '_async'

### DIFF
--- a/tests/data/example_custom_pkg/setup.py
+++ b/tests/data/example_custom_pkg/setup.py
@@ -1,0 +1,17 @@
+import setuptools
+
+import unasync
+
+setuptools.setup(
+    name="ahip",
+    version="0.0.1",
+    author="Example Author",
+    author_email="author@example.com",
+    description="A package used to test customized unasync",
+    url="https://github.com/pypa/sampleproject",
+    packages=["ahip", "ahip.some_dir"],
+    cmdclass={
+        "build_py": unasync.customize_build_py(rename_dir_from_to=("ahip", "hip"))
+    },
+    package_dir={"": "src"},
+)

--- a/tests/data/example_custom_pkg/src/ahip/__init__.py
+++ b/tests/data/example_custom_pkg/src/ahip/__init__.py
@@ -1,0 +1,2 @@
+async def f():
+    return await 1

--- a/tests/data/example_custom_pkg/src/ahip/another_file.py
+++ b/tests/data/example_custom_pkg/src/ahip/another_file.py
@@ -1,0 +1,2 @@
+async def f():
+    return await 1

--- a/tests/data/example_custom_pkg/src/ahip/some_dir/__init__.py
+++ b/tests/data/example_custom_pkg/src/ahip/some_dir/__init__.py
@@ -1,0 +1,2 @@
+async def f():
+    return await 1

--- a/tests/data/example_custom_pkg/src/ahip/some_dir/another_file.py
+++ b/tests/data/example_custom_pkg/src/ahip/some_dir/another_file.py
@@ -1,0 +1,2 @@
+async def f():
+    return await 1

--- a/tests/data/example_custom_pkg/src/ahip/some_dir/some_file.py
+++ b/tests/data/example_custom_pkg/src/ahip/some_dir/some_file.py
@@ -1,0 +1,2 @@
+async def f():
+    return await 1

--- a/tests/data/example_custom_pkg/src/ahip/some_file.py
+++ b/tests/data/example_custom_pkg/src/ahip/some_file.py
@@ -1,0 +1,2 @@
+async def f():
+    return await 1

--- a/tests/test_unasync.py
+++ b/tests/test_unasync.py
@@ -96,3 +96,19 @@ def test_project_structure_after_build_py_packages(tmpdir):
     )
 
     assert _async_dir_tree == unasynced_dir_tree
+
+
+def test_project_structure_after_customized_build_py_packages(tmpdir):
+
+    source_pkg_dir = os.path.join(TEST_DIR, "example_custom_pkg")
+    pkg_dir = str(tmpdir) + "/" + "example_custom_pkg"
+    shutil.copytree(source_pkg_dir, pkg_dir)
+
+    env = copy.copy(os.environ)
+    env["PYTHONPATH"] = os.path.realpath(os.path.join(TEST_DIR, ".."))
+    subprocess.check_call(["python", "setup.py", "build"], cwd=pkg_dir, env=env)
+
+    _async_dir_tree = list_files(os.path.join(source_pkg_dir, "src/ahip/."))
+    unasynced_dir_tree = list_files(os.path.join(pkg_dir, "build/lib/hip/."))
+
+    assert _async_dir_tree == unasynced_dir_tree


### PR DESCRIPTION
This allows the Hip project to use `ahip` -> `hip`.