### PR TITLE
Add unasync.unasync_files() API

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -86,6 +86,23 @@ customized :code:`unasync.Rule` instances to :code:`unasync.cmdclass_build_py()`
         ...
     )
 
+---------------------------
+Usage outside of setuptools
+---------------------------
+
+You can also use unasync without setuptools, to run unasync on tests, for example.
+
+.. code-block:: python
+
+    import unasync
+
+    unasync.unasync_files(
+        [file1, file2, ...],
+        rules=[
+            unasync.Rule("tests/", "tests_sync/", replacements={"ahip": "hip"}),
+        ]
+    )
+
 
 .. toctree::
    :maxdepth: 2

--- a/src/unasync/__init__.py
+++ b/src/unasync/__init__.py
@@ -108,6 +108,21 @@ class Rule:
         return name
 
 
+def unasync_files(fpath_list, rules):
+    for f in fpath_list:
+        found_rule = None
+        found_weight = None
+
+        for rule in rules:
+            weight = rule._match(f)
+            if weight and (found_weight is None or weight > found_weight):
+                found_rule = rule
+                found_weight = weight
+
+        if found_rule:
+            found_rule.unasync_file(f)
+
+
 Token = collections.namedtuple("Token", ["type", "string", "start", "end", "line"])
 
 
@@ -179,18 +194,7 @@ class _build_py(orig.build_py):
             self.build_package_data()
 
         # Our modification!
-        for f in self._updated_files:
-            found_rule = None
-            found_weight = None
-
-            for rule in rules:
-                weight = rule._match(f)
-                if weight and (found_weight is None or weight > found_weight):
-                    found_rule = rule
-                    found_weight = weight
-
-            if found_rule:
-                found_rule.unasync_file(f)
+        unasync_files(self._updated_files, rules)
 
         # Remaining base class code
         self.byte_compile(self.get_outputs(include_bytecode=0))

--- a/tests/test_unasync.py
+++ b/tests/test_unasync.py
@@ -47,6 +47,22 @@ def test_unasync(tmpdir, source_file):
         assert unasynced_code == truth
 
 
+def test_unasync_files(tmpdir):
+    """Test the unasync_files API, not tied by a Rule or to setuptools."""
+    unasync.unasync_files(
+        [os.path.join(ASYNC_DIR, fpath) for fpath in TEST_FILES],
+        rules=[unasync.Rule(fromdir=ASYNC_DIR, todir=str(tmpdir))],
+    )
+
+    for source_file in TEST_FILES:
+        encoding = "latin-1" if "encoding" in source_file else "utf-8"
+        with io.open(os.path.join(SYNC_DIR, source_file), encoding=encoding) as f:
+            truth = f.read()
+        with io.open(os.path.join(str(tmpdir), source_file), encoding=encoding) as f:
+            unasynced_code = f.read()
+            assert unasynced_code == truth
+
+
 def test_build_py_modules(tmpdir):
 
     source_modules_dir = os.path.join(TEST_DIR, "example_mod")


### PR DESCRIPTION
It allows to run unasync on multiple files using multiples rules if needed, without being tied to setuptools.

@sethmlarson Now that you taught me that using Rule.unasync_files directly made sense, I'm not sure if this is such a good idea. Right now, I have a proof-of-concept that works in hip using this API:

    import unasync

    unasync.unasync_files(
        [
            "test/with_dummyserver/sync/__init__.py",
            "test/with_dummyserver/async/test_poolmanager.py",
        ],
        rules=[
            unasync.Rule(
                "test/with_dummyserver/async",
                "test/with_dummyserver/sync",
                replacements={
                    "AsyncPoolManager": "PoolManager",
                    "test_all_backends": "test_sync_backend",
                },
            )
        ],
    )

Since I have only a single rule, I guess I could use Rule.unasync_file and loop over files. This pull request feels more general, and since I already had the code, I submitted it. Please tell me what you think.