### PR TITLE
Tweak API

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -81,7 +81,7 @@ customized :code:`unasync.Rule` instances to :code:`unasync.cmdclass_build_py()`
             # This rule's 'fromdir' is more specific so will take precedent
             # over the above rule if the path is within /ahip/tests/...
             # This rule adds an additional token replacement over the default replacements.
-            unasync.Rule("/ahip/tests/", "/hip/tests/", replacements={"ahip": "hip"}),
+            unasync.Rule("/ahip/tests/", "/hip/tests/", additional_replacements={"ahip": "hip"}),
         ])},
         ...
     )
@@ -99,7 +99,7 @@ You can also use unasync without setuptools, to run unasync on tests, for exampl
     unasync.unasync_files(
         [file1, file2, ...],
         rules=[
-            unasync.Rule("tests/", "tests_sync/", replacements={"ahip": "hip"}),
+            unasync.Rule("tests/", "tests_sync/", additional_replacements={"ahip": "hip"}),
         ]
     )
 

--- a/src/unasync/__init__.py
+++ b/src/unasync/__init__.py
@@ -63,7 +63,7 @@ class Rule:
 
         return False
 
-    def unasync_file(self, filepath):
+    def _unasync_file(self, filepath):
         with open(filepath, "rb") as f:
             write_kwargs = {}
             if sys.version_info[0] >= 3:
@@ -120,7 +120,7 @@ def unasync_files(fpath_list, rules):
                 found_weight = weight
 
         if found_rule:
-            found_rule.unasync_file(f)
+            found_rule._unasync_file(f)
 
 
 Token = collections.namedtuple("Token", ["type", "string", "start", "end", "line"])

--- a/src/unasync/__init__.py
+++ b/src/unasync/__init__.py
@@ -37,13 +37,13 @@ _ASYNC_TO_SYNC = {
 class Rule:
     """A single set of rules for 'unasync'ing file(s)"""
 
-    def __init__(self, fromdir, todir, replacements=None):
+    def __init__(self, fromdir, todir, additional_replacements=None):
         self.fromdir = fromdir.replace("/", os.sep)
         self.todir = todir.replace("/", os.sep)
 
         # Add any additional user-defined token replacements to our list.
         self.token_replacements = _ASYNC_TO_SYNC.copy()
-        for key, val in (replacements or {}).items():
+        for key, val in (additional_replacements or {}).items():
             self.token_replacements[key] = val
 
     def _match(self, filepath):

--- a/tests/data/example_custom_pkg/setup.py
+++ b/tests/data/example_custom_pkg/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
                 unasync.Rule(
                     fromdir="/ahip/tests/",
                     todir="/hip/tests/",
-                    replacements={"ahip": "hip"},
+                    additional_replacements={"ahip": "hip"},
                 ),
             ]
         )

--- a/tests/test_unasync.py
+++ b/tests/test_unasync.py
@@ -37,7 +37,7 @@ def test_rule_on_short_path():
 def test_unasync(tmpdir, source_file):
 
     rule = unasync.Rule(fromdir=ASYNC_DIR, todir=str(tmpdir))
-    rule.unasync_file(os.path.join(ASYNC_DIR, source_file))
+    rule._unasync_file(os.path.join(ASYNC_DIR, source_file))
 
     encoding = "latin-1" if "encoding" in source_file else "utf-8"
     with io.open(os.path.join(SYNC_DIR, source_file), encoding=encoding) as f:


### PR DESCRIPTION
* Rename `replacements` to `additional_replacements` (this is the name that Seth wanted to use initially, and it's just better)
* Mark `Rule.unasync_file` as private, now that `unasync.unasync_files` exists