### PR TITLE
Many 'o' fixes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,9 @@
 branch=True
 source=unasync
 
+[paths]
+source = src/unasync
+
 [report]
 precision = 1
 exclude_lines =

--- a/.coveragerc-py2
+++ b/.coveragerc-py2
@@ -7,4 +7,4 @@ precision = 1
 exclude_lines =
   pragma: no cover
   abc.abstractmethod
-  \# PY2
+  \# PY3

--- a/.coveragerc-py2
+++ b/.coveragerc-py2
@@ -2,6 +2,9 @@
 branch=True
 source=unasync
 
+[paths]
+source = src/unasync
+
 [report]
 precision = 1
 exclude_lines =

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -51,6 +51,16 @@ if [ "$USE_PYPY_RELEASE_VERSION" != "" ]; then
     source testenv/bin/activate
 fi
 
+case "${MACPYTHON:-${TRAVIS_PYTHON_VERSION:-}}" in
+	2*)
+		COVERAGE_FILE=.coveragerc-py2
+	;;
+
+	*)
+		COVERAGE_FILE=.coveragerc
+	;;
+esac
+
 pip install -U pip setuptools wheel
 
 if [ "$CHECK_FORMATTING" = "1" ]; then
@@ -91,7 +101,7 @@ else
     mkdir empty
     cd empty
 
-    pytest -ra -v --cov=unasync --cov-config=../.coveragerc --verbose ../tests
+    pytest -ra -v --cov=unasync --cov-config="../${COVERAGE_FILE}" --verbose ../tests
 
     bash <(curl -s https://codecov.io/bash)
 fi

--- a/src/unasync/__init__.py
+++ b/src/unasync/__init__.py
@@ -149,7 +149,7 @@ def _tokenize(f):
         space = ""
         if tok.start > last_end:
             assert tok.start[0] == last_end[0]
-            space = " " * (tok.start[1] - last_end[1])
+            space = tok.line[last_end[1] : tok.start[1]]
         yield (space, tok.type, tok.string)
 
         last_end = tok.end

--- a/src/unasync/__init__.py
+++ b/src/unasync/__init__.py
@@ -67,7 +67,7 @@ class Rule:
     def _unasync_file(self, filepath):
         with open(filepath, "rb") as f:
             write_kwargs = {}
-            if sys.version_info[0] >= 3:
+            if sys.version_info[0] >= 3:  # PY3  # pragma: no branch
                 encoding, _ = std_tokenize.detect_encoding(f.readline)
                 write_kwargs["encoding"] = encoding
                 f.seek(0)
@@ -128,11 +128,11 @@ Token = collections.namedtuple("Token", ["type", "string", "start", "end", "line
 
 
 def _get_tokens(f):
-    if sys.version_info[0] == 2:
+    if sys.version_info[0] == 2:  # PY2
         for tok in std_tokenize.generate_tokens(f.readline):
             type_, string, start, end, line = tok
             yield Token(type_, string, start, end, line)
-    else:
+    else:  # PY3
         for tok in std_tokenize.tokenize(f.readline):
             if tok.type == std_tokenize.ENCODING:
                 continue

--- a/src/unasync/__init__.py
+++ b/src/unasync/__init__.py
@@ -52,13 +52,18 @@ else:  # PY3
 
     StringIO = io.StringIO
 
+if hasattr(os, "fspath"):  # PY3
+    fspath = os.fspath
+else:  # PY2
+    fspath = str
+
 
 class Rule:
     """A single set of rules for 'unasync'ing file(s)"""
 
     def __init__(self, fromdir, todir, additional_replacements=None):
-        self.fromdir = fromdir.replace("/", os.sep)
-        self.todir = todir.replace("/", os.sep)
+        self.fromdir = fspath(fromdir).replace("/", os.sep)
+        self.todir = fspath(todir).replace("/", os.sep)
 
         # Add any additional user-defined token replacements to our list.
         self.token_replacements = _ASYNC_TO_SYNC.copy()
@@ -69,6 +74,8 @@ class Rule:
         """Determines if a Rule matches a given filepath and if so
         returns a higher comparable value if the match is more specific.
         """
+        filepath = fspath(filepath)
+
         file_segments = [x for x in filepath.split(os.sep) if x]
         from_segments = [x for x in self.fromdir.split(os.sep) if x]
         len_from_segments = len(from_segments)
@@ -83,6 +90,7 @@ class Rule:
         return False
 
     def _unasync_file(self, filepath):
+        filepath = fspath(filepath)
         with open(filepath, "rb") as f:
             write_kwargs = {}
             if sys.version_info[0] >= 3:  # PY3  # pragma: no branch

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 pytest>=4.3.0
 pytest-cov
+pathlib2 ; python_version < '3.5'

--- a/tests/data/async/tabs.py
+++ b/tests/data/async/tabs.py
@@ -1,0 +1,8 @@
+# fmt: off
+async def dummy():
+	await dummy2()  # This line is indented with a tab that should be preserved
+# fmt: on
+
+
+async def dummy2():
+    await dummy()  # This one uses 4 spaces and these should also be preserved

--- a/tests/data/async/typing.py
+++ b/tests/data/async/typing.py
@@ -3,3 +3,26 @@ import typing
 typing.AsyncIterable[bytes]
 typing.AsyncIterator[bytes]
 typing.AsyncGenerator[bytes]
+
+# A typed function that takes the first item of an (a)sync iterator and returns it
+async def func1(a: typing.AsyncIterable[int]) -> str:
+    it: typing.AsyncIterator[int] = a.__aiter__()
+    b: int = await it.__anext__()
+    return str(b)
+
+
+# Same as the above but using old-style typings (mainly for Python 2.7 – 3.5 compatibility)
+async def func2(a):  # type: (typing.AsyncIterable[int]) -> str
+    it = a.__aiter__()  # type: typing.AsyncIterator[int]
+    b = await it.__anext__()  # type: int
+    return str(b)
+
+
+# And some funky edge cases to at least cover the relevant at all in this test
+a: int = 5
+b: str = a  # type: ignore  # This is the actual comment and the type declaration silences the warning that would otherwise happen
+c: str = a  # type: ignore2  # This is the actual comment and the declaration declares another type, both of which are wrong
+
+# fmt: off
+# And some genuine trailing whitespace (uww…)
+z = a  # type: int   

--- a/tests/data/async/typing_py3.py
+++ b/tests/data/async/typing_py3.py
@@ -1,0 +1,13 @@
+# fmt: off
+# A forward-reference typed function that returns an iterator for an (a)sync iterable
+async def aiter1(a: "typing.AsyncIterable[int]") -> 'typing.AsyncIterable[int]':
+	return a.__aiter__()
+
+# Same as the above but using tripple-quoted strings
+async def aiter2(a: """typing.AsyncIterable[int]""") -> r'''typing.AsyncIterable[int]''':
+	return a.__aiter__()
+
+# Same as the above but without forward-references
+async def aiter3(a: typing.AsyncIterable[int]) -> typing.AsyncIterable[int]:
+	return a.__aiter__()
+# fmt: on

--- a/tests/data/sync/tabs.py
+++ b/tests/data/sync/tabs.py
@@ -1,0 +1,8 @@
+# fmt: off
+def dummy():
+	dummy2()  # This line is indented with a tab that should be preserved
+# fmt: on
+
+
+def dummy2():
+    dummy()  # This one uses 4 spaces and these should also be preserved

--- a/tests/data/sync/typing.py
+++ b/tests/data/sync/typing.py
@@ -3,3 +3,26 @@ import typing
 typing.Iterable[bytes]
 typing.Iterator[bytes]
 typing.Generator[bytes]
+
+# A typed function that takes the first item of an (a)sync iterator and returns it
+def func1(a: typing.Iterable[int]) -> str:
+    it: typing.Iterator[int] = a.__iter__()
+    b: int = it.__next__()
+    return str(b)
+
+
+# Same as the above but using old-style typings (mainly for Python 2.7 – 3.5 compatibility)
+def func2(a):  # type: (typing.Iterable[int]) -> str
+    it = a.__iter__()  # type: typing.Iterator[int]
+    b = it.__next__()  # type: int
+    return str(b)
+
+
+# And some funky edge cases to at least cover the relevant at all in this test
+a: int = 5
+b: str = a  # type: ignore  # This is the actual comment and the type declaration silences the warning that would otherwise happen
+c: str = a  # type: ignore2  # This is the actual comment and the declaration declares another type, both of which are wrong
+
+# fmt: off
+# And some genuine trailing whitespace (uww…)
+z = a  # type: int   

--- a/tests/data/sync/typing_py3.py
+++ b/tests/data/sync/typing_py3.py
@@ -1,0 +1,13 @@
+# fmt: off
+# A forward-reference typed function that returns an iterator for an (a)sync iterable
+def aiter1(a: "typing.Iterable[int]") -> 'typing.Iterable[int]':
+	return a.__iter__()
+
+# Same as the above but using tripple-quoted strings
+def aiter2(a: """typing.Iterable[int]""") -> r'''typing.Iterable[int]''':
+	return a.__iter__()
+
+# Same as the above but without forward-references
+def aiter3(a: typing.Iterable[int]) -> typing.Iterable[int]:
+	return a.__iter__()
+# fmt: on

--- a/tests/test_unasync.py
+++ b/tests/test_unasync.py
@@ -19,6 +19,11 @@ TEST_FILES = sorted([f for f in os.listdir(ASYNC_DIR) if f.endswith(".py")])
 def list_files(startpath):
     output = ""
     for root, dirs, files in os.walk(startpath):
+        # Ensure that we do not capture the directory inode order on
+        # platforms that don't pre-sort `readdir` results
+        dirs.sort()
+        files.sort()
+
         level = root.replace(startpath, "").count(os.sep)
         indent = " " * 4 * (level)
         output += "{}{}/".format(indent, os.path.basename(root))

--- a/tests/test_unasync.py
+++ b/tests/test_unasync.py
@@ -2,6 +2,11 @@ import copy
 import errno
 import io
 import os
+
+try:
+    import pathlib
+except ImportError:
+    import pathlib2 as pathlib
 import shutil
 import subprocess
 import sys
@@ -41,6 +46,12 @@ def list_files(startpath):
 def test_rule_on_short_path():
     rule = unasync.Rule("/ahip/tests/", "/hip/tests/")
     assert rule._match("/ahip/") is False
+
+
+def test_rule_with_pathlib_path():
+    path_async_base = pathlib.Path("/ahip")
+    path_sync_base = pathlib.Path("/hip")
+    unasync.Rule(path_async_base / "tests", path_sync_base / "tests")
 
 
 @pytest.mark.parametrize("source_file", TEST_FILES)

--- a/tests/test_unasync.py
+++ b/tests/test_unasync.py
@@ -15,6 +15,9 @@ ASYNC_DIR = os.path.join(TEST_DIR, "async")
 SYNC_DIR = os.path.join(TEST_DIR, "sync")
 TEST_FILES = sorted([f for f in os.listdir(ASYNC_DIR) if f.endswith(".py")])
 
+if sys.version_info[0] == 2:
+    TEST_FILES.remove("typing_py3.py")
+
 
 def list_files(startpath):
     output = ""

--- a/tests/test_unasync.py
+++ b/tests/test_unasync.py
@@ -4,6 +4,7 @@ import io
 import os
 import shutil
 import subprocess
+import sys
 
 import pytest
 
@@ -72,9 +73,9 @@ def test_build_py_modules(tmpdir):
 
     env = copy.copy(os.environ)
     env["PYTHONPATH"] = os.path.realpath(os.path.join(TEST_DIR, ".."))
-    subprocess.check_call(["python", "setup.py", "build"], cwd=mod_dir, env=env)
+    subprocess.check_call([sys.executable, "setup.py", "build"], cwd=mod_dir, env=env)
     # Calling it twice to test the "if not copied" branch
-    subprocess.check_call(["python", "setup.py", "build"], cwd=mod_dir, env=env)
+    subprocess.check_call([sys.executable, "setup.py", "build"], cwd=mod_dir, env=env)
 
     unasynced = os.path.join(mod_dir, "build/lib/_sync/some_file.py")
     tree_build_dir = list_files(mod_dir)
@@ -92,7 +93,7 @@ def test_build_py_packages(tmpdir):
 
     env = copy.copy(os.environ)
     env["PYTHONPATH"] = os.path.realpath(os.path.join(TEST_DIR, ".."))
-    subprocess.check_call(["python", "setup.py", "build"], cwd=pkg_dir, env=env)
+    subprocess.check_call([sys.executable, "setup.py", "build"], cwd=pkg_dir, env=env)
 
     unasynced = os.path.join(pkg_dir, "build/lib/example_pkg/_sync/__init__.py")
 
@@ -109,7 +110,7 @@ def test_project_structure_after_build_py_packages(tmpdir):
 
     env = copy.copy(os.environ)
     env["PYTHONPATH"] = os.path.realpath(os.path.join(TEST_DIR, ".."))
-    subprocess.check_call(["python", "setup.py", "build"], cwd=pkg_dir, env=env)
+    subprocess.check_call([sys.executable, "setup.py", "build"], cwd=pkg_dir, env=env)
 
     _async_dir_tree = list_files(
         os.path.join(source_pkg_dir, "src/example_pkg/_async/.")
@@ -129,7 +130,7 @@ def test_project_structure_after_customized_build_py_packages(tmpdir):
 
     env = copy.copy(os.environ)
     env["PYTHONPATH"] = os.path.realpath(os.path.join(TEST_DIR, ".."))
-    subprocess.check_call(["python", "setup.py", "build"], cwd=pkg_dir, env=env)
+    subprocess.check_call([sys.executable, "setup.py", "build"], cwd=pkg_dir, env=env)
 
     _async_dir_tree = list_files(os.path.join(source_pkg_dir, "src/ahip/."))
     unasynced_dir_path = os.path.join(pkg_dir, "build/lib/hip/.")


### PR DESCRIPTION
Many fixes for:

  * Running tests on Debian/Linux
  * Coverage reporting wrt Python 2 & 3 only code
  * Source code indented with tabs (like all of mine)
  * Type comments (old-style typings for compatiblity with Python 2.7 and, in some cases, 3.5)
  * Forward-references (string values in typings)
  * `pathlib.Path`/`os.fspath` filesystem paths