### PR TITLE
Replace tokenization with tokenize_rt

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -4,7 +4,7 @@ set -ex
 
 BLACK_VERSION=22.6.0
 
-pip install -U pip setuptools wheel
+python -m pip install -U pip setuptools wheel
 
 python setup.py sdist --formats=zip
 pip install dist/*.zip

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     include_package_data=True,
     packages=find_packages("src"),
     package_dir={"": "src"},
-    install_requires=["tokenize_rt==4.2.1"],
+    install_requires=["tokenize_rt"],
     keywords=["async"],
     python_requires=">=3.7",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     include_package_data=True,
     packages=find_packages("src"),
     package_dir={"": "src"},
-    install_requires=[],
+    install_requires=["tokenize_rt==4.2.1"],
     keywords=["async"],
     python_requires=">=3.7",
     classifiers=[


### PR DESCRIPTION
The standard library module `tokenize` does not round trip, so we had to
implement our own tokenization on top of it. However, `tokenize_rt` does
it better and will enable #75, so let's adopt it instead.