### PR TITLE
Make Rule's unasync functions public for overwriting

### DIFF
--- a/newsfragments/84.feature.rst
+++ b/newsfragments/84.feature.rst
@@ -1,0 +1,1 @@
+Add public methods ``unasync_name`` and ``unasync_string`` to ``Rule`` to allow for easier customization via inheritance.

--- a/src/unasync/__init__.py
+++ b/src/unasync/__init__.py
@@ -89,26 +89,29 @@ class Rule:
                 skip_next = True
             else:
                 if token.name == "NAME":
-                    token = token._replace(src=self._unasync_name(token.src))
+                    token = token._replace(src=self.unasync_name(token.src))
                 elif token.name == "STRING":
-                    left_quote, name, right_quote = (
+                    left_quote, string, right_quote = (
                         token.src[0],
                         token.src[1:-1],
                         token.src[-1],
                     )
                     token = token._replace(
-                        src=left_quote + self._unasync_name(name) + right_quote
+                        src=left_quote + self.unasync_string(string) + right_quote
                     )
 
                 yield token
 
-    def _unasync_name(self, name):
+    def unasync_name(self, name):
         if name in self.token_replacements:
             return self.token_replacements[name]
         # Convert classes prefixed with 'Async' into 'Sync'
         elif len(name) > 5 and name.startswith("Async") and name[5].isupper():
             return "Sync" + name[5:]
         return name
+
+    def unasync_string(self, string):
+        return self.unasync_name(string)
 
 
 def unasync_files(fpath_list, rules):


### PR DESCRIPTION
I propose to make the `unasync` functions of `Rule` public so that custom `Rule` implementations can more easily inherit from `Rule` and change the exact replacement mechanisms.

Here are my use-cases that this would enable without having to rely on internal APIs:
 * I have code examples in doc strings and I want to unasync those as well. Hence the need for a custom `unasync_string`)
 * I have doc references that I want to unasync. E.g., from <code>:ref:\`async-thingamajig\`</code> to <code>:ref:\`thingamajig\`</code>.
 * I want to have a more complex replacement customization that just a hard-coded mapping of identifiers. E.g. something like this
    ```python
    len(name) > 6 and name.startswith("async_"):
        return name[6:]
    ```