### PR TITLE
Allow for custom file path mapping

### DIFF
--- a/newsfragments/85.feature.rst
+++ b/newsfragments/85.feature.rst
@@ -1,0 +1,1 @@
+Add public method ``map_in_to_out_file_path`` to ``Rule`` to allow for easier customization via inheritance.

--- a/src/unasync/__init__.py
+++ b/src/unasync/__init__.py
@@ -71,10 +71,13 @@ class Rule:
             tokens = tokenize_rt.src_to_tokens(f.read())
             tokens = self._unasync_tokens(tokens)
             result = tokenize_rt.tokens_to_src(tokens)
-            outfilepath = filepath.replace(self.fromdir, self.todir)
+            outfilepath = self.map_in_to_out_file_path(filepath)
             os.makedirs(os.path.dirname(outfilepath), exist_ok=True)
             with open(outfilepath, "wb") as f:
                 f.write(result.encode(encoding))
+
+    def map_in_to_out_file_path(self, in_file_path):
+        return in_file_path.replace(self.fromdir, self.todir)
 
     def _unasync_tokens(self, tokens):
         skip_next = False


### PR DESCRIPTION
I have a rather involved unasync workflow that integrates with pre-commit and isort (because after unasyncing, the import order often changes as things get renamed).

For this to work, I need to be able to put the unasynced files into a different place temporarily to further process them (run isort, check the diff, ...). Now, I *could* use a temporary directory but mapping files that way is more complicated to manage (e.g., clean-up when the process is interrupted in the middle, mapping of files).

Therefore, I'd really appreciate a way to customize exactly what path the unasync output is being written to.