### PR TITLE
Make list_files() traversal deterministic

### DIFF
--- a/tests/test_unasync.py
+++ b/tests/test_unasync.py
@@ -17,6 +17,8 @@ TEST_FILES = sorted(f for f in os.listdir(ASYNC_DIR) if f.endswith(".py"))
 def list_files(startpath):
     output = ""
     for root, dirs, files in os.walk(startpath):
+        dirs.sort()
+        files.sort()
         level = root.replace(startpath, "").count(os.sep)
         indent = " " * 4 * (level)
         output += f"{indent}{os.path.basename(root)}/"


### PR DESCRIPTION
list_files() is used by test_project_structure_after_customized_build_py_packages to compare the source package layout with the generated package layout.

The helper currently relies on the traversal order returned by os.walk(). Since os.walk() does not guarantee the order of sibling directories or files, two identical directory trees can produce different textual representations, causing the test to fail even though the generated package structure is correct.

This change sorts both dirs and files before traversal, making the comparison deterministic while preserving the intent of the test.